### PR TITLE
Improve arguments for calling docker run command

### DIFF
--- a/k8sviz.sh
+++ b/k8sviz.sh
@@ -81,6 +81,10 @@ if [ ! -f "${KUBECONFIG}" ];then
   exit 1
 fi
 
-docker run --network host -v ${ABSDIR}:/work -v ${KUBECONFIG}:/config:ro \
-  -e KUBECONFIG=/config -it ${CONTAINER_IMG} /k8sviz -kubeconfig /config \
+docker run --network host                        \
+  --user $(id -u):$(id -g)                       \
+  -v ${ABSDIR}:/work                             \
+  -v ${KUBECONFIG}:/config:ro                    \
+  -it --rm ${CONTAINER_IMG}                      \
+  /k8sviz -kubeconfig /config                    \
   -n ${NAMESPACE} -t ${TYPE} -o /work/${FILENAME}


### PR DESCRIPTION
This PR Improves arguments for calling docker run command:
- Add --user option to create file as the user's context
- Add --rm option to remove container after execution
- Remove -e KUBECONFIG that are actually not in use

