### PR TITLE
Use .kube/config as the default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flags:
   -n,--namespace:  The namespace to visualize. (default: 'default')
   -o,--outfile:  The filename to output. (default: 'k8sviz.out')
   -t,--type:  The type of output. (default: 'dot')
-  -k,--kubeconfig:  Path to kubeconfig file. (default: '/home/user1/kubeconfig')
+  -k,--kubeconfig:  Path to kubeconfig file. (default: '/home/user1/.kube/config')
   -i,--image:  Image name of the container. (default: 'mkimuram/k8sviz:0.3')
   -h,--help:  show this help (default: false)
 ```

--- a/k8sviz.sh
+++ b/k8sviz.sh
@@ -4,7 +4,7 @@
 NAMESPACE="default"
 OUTFILE="k8sviz.out"
 TYPE="dot"
-KUBECONFIG=~/kubeconfig
+KUBECONFIG=~/.kube/config
 CONTAINER_IMG=mkimuram/k8sviz:0.3
 SHFLAGS_DIR="$(dirname ${BASH_SOURCE})/lib/"
 SHFLAGS_PATH="${SHFLAGS_DIR}shflags"


### PR DESCRIPTION
I guess I don't see why there would be a different default path for the shell script version, so I suggest we change it to the same as the Go version.