### PR TITLE
Fix default namespace for go version to be `default`

### DIFF
--- a/cmd/k8sviz/main.go
+++ b/cmd/k8sviz/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultNamespace   = "namespace"
+	defaultNamespace   = "default"
 	defaultOutFile     = "k8sviz.out"
 	defaultOutType     = "dot"
 	descNamespaceOpt   = "namespace to visualize"


### PR DESCRIPTION
This PR fixes default namespace for go version to be `default`.

Fixes: #41 