### PR TITLE
Provide a way to build custom image with AWS SDK/Google Cloud SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,17 @@ RUN apk add --no-cache \
     && pip3 install \
         awscli \
     && rm -rf /var/cache/apk/*
+
+FROM vanilla AS gcloud
+RUN apk add --no-cache \
+        python3 \
+        curl \
+    && curl -L -o /tmp/google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
+    && mkdir -p /usr/local/share \
+    && tar -C /usr/local/share -xvf /tmp/google-cloud-sdk.tar.gz \
+    && /usr/local/share/google-cloud-sdk/install.sh \
+    && rm /tmp/google-cloud-sdk.tar.gz \
+    && rm -rf /var/cache/apk/*
+ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+ENV GOOGLE_APPLICATION_CREDENTIALS /service-account-key.json
+RUN if [ -f /service-account-key.json ]; then rm /service-account-key.json; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,19 @@ WORKDIR /src
 COPY . .
 RUN make build
 
-FROM alpine:3.11
+FROM alpine:3.11 AS vanilla
 RUN apk add --no-cache bash graphviz ttf-linux-libertine
 
 COPY icons /icons
 COPY --from=build /src/bin/k8sviz /
 
 CMD /k8sviz
+
+FROM vanilla AS aws
+RUN apk add --no-cache \
+        python3 \
+        py3-pip \
+    && pip3 install --upgrade pip \
+    && pip3 install \
+        awscli \
+    && rm -rf /var/cache/apk/*

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMAGE ?= mkimuram/k8sviz
 TAG ?= $(shell cat version.txt)
 DEVEL_IMAGE ?= k8sviz
 DEVEL_TAG ?= devel
+TARGET ?= vanilla
 
 test: test-lint test-fmt test-vet test-unit
 	@echo "[Running test]"
@@ -39,7 +40,7 @@ release: test build test-e2e
 
 image-build:
 	@echo "[Building image $(DEVEL_IMAGE):$(DEVEL_TAG)]"
-	docker build -t $(DEVEL_IMAGE):$(DEVEL_TAG) .
+	docker build -t $(DEVEL_IMAGE):$(DEVEL_TAG) --target $(TARGET) .
 
 image-push: image-build
 	@echo "[Pushing image $(IMAGE):$(TAG)]"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ flags:
 
 - 📝NOTE
 
-	If you can't pull the container image and need to build it by yourself,
+	If you can't pull the container image or need to build it by yourself,
 	you can do it by `make image-build`. It would be helpful if you specify
 	`DEVEL_IMAGE` and `DEVEL_TAG` to make the image name the same to the
 	default one (Below example will set image name to `mkimuram/k8sviz:0.3`).
@@ -91,10 +91,14 @@ flags:
 	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) make image-build
 	```
 
-	An example use case of creating custom image is to include aws_sdk.
-	To create a custom image that include aws_sdk, run below command:
+	An example use case of creating custom image is to include AWS SDK or Google Cloud SDK.
+	To create a custom image that include AWS SDK, run below command:
 	```shell
 	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=aws make image-build
+	```
+	To create a custom image that include Google Cloud SDK, run below command:
+	```shell
+	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=gcloud make image-build
 	```
 
 ### Go version

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ flags:
 	`DEVEL_IMAGE` and `DEVEL_TAG` to make the image name the same to the
 	default one (Below example will set image name to `mkimuram/k8sviz:0.3`).
 	```shell
-	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=0.3 make image-build
+	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) make image-build
+	```
+
+	An example use case of creating custom image is to include aws_sdk.
+	To create a custom image that include aws_sdk, run below command:
+	```shell
+	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=aws make image-build
 	```
 
 ### Go version

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ flags:
 	If you can't pull the container image or need to build it by yourself,
 	you can do it by `make image-build`. It would be helpful if you specify
 	`DEVEL_IMAGE` and `DEVEL_TAG` to make the image name the same to the
-	default one (Below example will set image name to `mkimuram/k8sviz:0.3`).
+	default one (Below example will set image name like `mkimuram/k8sviz:0.3.4`).
 	```shell
 	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) make image-build
 	```
@@ -108,9 +108,9 @@ Usage of ./k8sviz:
   -kubeconfig string
         absolute path to the kubeconfig file (default "/home/user1/.kube/config")
   -n string
-        namespace to visualize (shorthand) (default "namespace")
+        namespace to visualize (shorthand) (default "default")
   -namespace string
-        namespace to visualize (default "namespace")
+        namespace to visualize (default "default")
   -o string
         output filename (shorthand) (default "k8sviz.out")
   -outfile string


### PR DESCRIPTION
This PR provides a way to build a custom image with AWS SDK/Google Cloud SDK.
By specifying `TARGET=aws` or `TARGET=gcloud` to `make image-build`, sdk can be included in the container image.
