### PR TITLE
Add flag for supplying path to directory containing icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,31 @@ Currently, this only generates a diagram similar to https://github.com/kubernete
 For examples of the generated diagrams, see [Examples](#examples) below.
 
 ## Implementations
-There are two implementations, bash script version and go version. Bash script version is just a wrapper to run go version inside container. 
+
+There are two implementations, bash script version and go version. Bash script version is just a wrapper to run go version inside a Docker container.
 
 ## Prerequisites
+
 ### Bash script version
+
 `k8sviz.sh` requires:
+
 - bash
 - getopt
 - docker
 
 To build a container image (optional), it requires:
+
 - make
 
 ### Go version
+
 `k8sviz` requires:
+
 - dot (graphviz) command
 
 To build binary, it requires:
+
 - make
 - go
 
@@ -33,35 +41,45 @@ To build binary, it requires:
 | k8sviz 0.3.3 or later   |  No                 |  Yes              |
 
 ## Installation
+
 ### Bash script version
+
 Just download `k8sviz.sh` file and add execute permission.
+
 ```shell
-$ curl -LO https://raw.githubusercontent.com/mkimuram/k8sviz/master/k8sviz.sh
-$ chmod u+x k8sviz.sh
+curl -LO https://raw.githubusercontent.com/mkimuram/k8sviz/master/k8sviz.sh
+chmod u+x k8sviz.sh
 ```
 
 ### Go version
+
 Build the binary with below commands:
+
 ```shell
-$ git clone https://github.com/mkimuram/k8sviz.git
-$ cd k8sviz
-$ make build
+git clone https://github.com/mkimuram/k8sviz.git
+cd k8sviz
+make build
 ```
 
 By default, the `icons` directory is expected to be in the same directory as the `k8sviz` binary.
 So, move them to the proper directory (Replace `PATH_TO_INSTALL` as you like).
+
 ```shell
-$ PATH_TO_INSTALL=$HOME/bin
-$ cp bin/k8sviz ${PATH_TO_INSTALL}
-$ cp -r icons ${PATH_TO_INSTALL}
+PATH_TO_INSTALL=$HOME/bin
+cp bin/k8sviz ${PATH_TO_INSTALL}
+cp -r icons ${PATH_TO_INSTALL}
 ```
 
 In case you wish to not put them in the same directory, you can run `k8sviz` with the command line flag `--icons` to pass the path to the directory containing the required icons.
 The path can either be relative to the binary (e.g. `../share/icons`) or absolute (e.g. `/usr/share/k8sviz/icons`).
+
 ## Usage
+
 ### Bash script version
+
 ```shell
-$ ./k8sviz.sh --help
+> ./k8sviz.sh --help
+
 USAGE: ./k8sviz.sh [flags] args
 flags:
   -n,--namespace:  The namespace to visualize. (default: 'default')
@@ -74,72 +92,90 @@ flags:
 
 - ⚠️ WARNING
 
-	If you are using Mac, only short options can be used.
-	If you would like to use long options, you can install gnu-getopt and enable it by defining
-	`FLAGS_GETOPT_CMD` environment variable.
-	```shell
-	$ brew install gnu-getopt
-	$ export FLAGS_GETOPT_CMD=/usr/local/opt/gnu-getopt/bin/getopt
-	$ ./k8sviz.sh -h
-	```
+  If you are using Mac, only short options can be used.
+  If you would like to use long options, you can install gnu-getopt and enable it by defining
+  `FLAGS_GETOPT_CMD` environment variable.
+
+  ```shell
+  brew install gnu-getopt
+  export FLAGS_GETOPT_CMD=/usr/local/opt/gnu-getopt/bin/getopt
+  ./k8sviz.sh -h
+  ```
 
 - 📝NOTE
 
-	If you can't pull the container image or need to build it by yourself,
-	you can do it by `make image-build`. It would be helpful if you specify
-	`DEVEL_IMAGE` and `DEVEL_TAG` to make the image name the same to the
-	default one (Below example will set image name like `mkimuram/k8sviz:0.3.4`).
-	```shell
-	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) make image-build
-	```
+  If you can't pull the container image or need to build it by yourself,
+  you can do it by `make image-build`. It would be helpful if you specify
+  `DEVEL_IMAGE` and `DEVEL_TAG` to make the image name the same to the
+  default one (Below example will set image name like `mkimuram/k8sviz:0.3.4`).
 
-	An example use case of creating custom image is to include AWS SDK or Google Cloud SDK.
-	To create a custom image that include AWS SDK, run below command:
-	```shell
-	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=aws make image-build
-	```
-	To create a custom image that include Google Cloud SDK, run below command:
-	```shell
-	$ DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=gcloud make image-build
-	```
+  ```shell
+  DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) make image-build
+  ```
+
+  An example use case of creating custom image is to include AWS SDK or Google Cloud SDK.
+  To create a custom image that include AWS SDK, run below command:
+
+  ```shell
+  DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=aws make image-build
+  ```
+
+  To create a custom image that include Google Cloud SDK, run below command:
+
+  ```shell
+  DEVEL_IMAGE=mkimuram/k8sviz DEVEL_TAG=$(cat version.txt) TARGET=gcloud make image-build
+  ```
 
 ### Go version
+
 ```shell
-$ ./k8sviz -h
+> ./k8sviz -h
+
 Usage of ./k8sviz:
+  -i string
+      path of directory containing icons (shorthand) (default "icons")
+  -icons string
+      path of directory containing icons (default "icons")
   -kubeconfig string
-        absolute path to the kubeconfig file (default "/home/user1/.kube/config")
+      absolute path to the kubeconfig file (default "/home/mathym/.kube/config")
   -n string
-        namespace to visualize (shorthand) (default "default")
+      namespace to visualize (shorthand) (default "default")
   -namespace string
-        namespace to visualize (default "default")
+      namespace to visualize (default "default")
   -o string
-        output filename (shorthand) (default "k8sviz.out")
+      output filename (shorthand) (default "k8sviz.out")
   -outfile string
-        output filename (default "k8sviz.out")
+      output filename (default "k8sviz.out")
   -t string
-        type of output (shorthand) (default "dot")
+      type of output (shorthand) (default "dot")
   -type string
-        type of output (default "dot")
+      type of output (default "dot")
 ```
 
 ## Examples
+
 Examples are only shown for old bash script version, but current go version should work in the same way.
 
 ### Examples for tutorial deployments in default namespace
+
 - Generate dot file for namespace `default`
-	```shell
-	 ./k8sviz.sh -n default -o default.dot
-	```
+
+  ```shell
+  ./k8sviz.sh -n default -o default.dot
+  ```
+
 - Generate png file for namespace `default`
-	```shell
-	$ ./k8sviz.sh -n default -t png -o default.png
-	```
+
+  ```shell
+  ./k8sviz.sh -n default -t png -o default.png
+  ```
+
 - Output for [an example wordpress deployment](https://kubernetes.io/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/) will be like below:
    - [default.dot](./examples/wordpress/default.dot)
    - [default.png](./examples/wordpress/default.png):
 
 <a href="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/wordpress/default.png"><img src="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/wordpress/default.png" width="40%" height="40%"/></a>
+
 - Output for [an example cassandra deployment with statefulset](https://kubernetes.io/docs/tutorials/stateful-application/cassandra/) will be like below:
    - [default.dot](./examples/cassandra/default.dot)
    - [default.png](./examples/cassandra/default.png):
@@ -147,16 +183,21 @@ Examples are only shown for old bash script version, but current go version shou
 <a href="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/cassandra/default.png"><img src="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/cassandra/default.png" width="50%" height="50%"/></a>
 
 ### Examples for more complex deployment ([kubeflow](https://www.kubeflow.org/docs/started/k8s/kfctl-k8s-istio/) case)
+
 - Generate dot file for namespace `kubeflow` and `istio-system`
-	```shell
-	$ ./k8sviz.sh -n kubeflow -o examples/kubeflow/kubeflow.dot
-	$ ./k8sviz.sh -n istio-system -o examples/kubeflow/istio-system.dot
-	```
+
+  ```shell
+  ./k8sviz.sh -n kubeflow -o examples/kubeflow/kubeflow.dot
+  ./k8sviz.sh -n istio-system -o examples/kubeflow/istio-system.dot
+  ```
+
 - Generate png file for namespace `kubeflow` and `istio-system`
-	```shell
-	$ ./k8sviz.sh -n kubeflow -t png -o examples/kubeflow/kubeflow.png
-	$ ./k8sviz.sh -n istio-system -t png -o examples/kubeflow/istio-system.png
-	```
+
+  ```shell
+  ./k8sviz.sh -n kubeflow -t png -o examples/kubeflow/kubeflow.png
+  ./k8sviz.sh -n istio-system -t png -o examples/kubeflow/istio-system.png
+  ```
+
 - Output:
    - [kubeflow.dot](./examples/kubeflow/kubeflow.dot)
    - [istio-system.dot](./examples/kubeflow/istio-system.dot)
@@ -169,4 +210,5 @@ Examples are only shown for old bash script version, but current go version shou
    <a href="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/kubeflow/istio-system.png"><img src="https://raw.githubusercontent.com/mkimuram/k8sviz/master/examples/kubeflow/istio-system.png" width="90%" height="90%"/></a>
 
 ## License
+
 This project is licensed under the Apache License - see the [LICENSE file](./LICENSE) for details

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ cd k8sviz
 $ make build
 ```
 
-`icons` directory needs to be in the same directory to the k8sviz binary.
+By default, the `icons` directory is expected to be in the same directory as the `k8sviz` binary.
 So, move them to the proper directory (Replace `PATH_TO_INSTALL` as you like).
 ```shell
 $ PATH_TO_INSTALL=$HOME/bin
@@ -56,6 +56,8 @@ $ cp bin/k8sviz ${PATH_TO_INSTALL}
 $ cp -r icons ${PATH_TO_INSTALL}
 ```
 
+In case you wish to not put them in the same directory, you can run `k8sviz` with the command line flag `--icons` to pass the path to the directory containing the required icons.
+The path can either be relative to the binary (e.g. `../share/icons`) or absolute (e.g. `/usr/share/k8sviz/icons`).
 ## Usage
 ### Bash script version
 ```shell

--- a/k8sviz.sh
+++ b/k8sviz.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 #### Variables ####
 NAMESPACE="default"

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -17,14 +17,15 @@ import (
 
 // Graph represents a graph of k8s resources
 type Graph struct {
-	dir  string
-	res  *resources.Resources
-	gviz *gographviz.Graph
+	dir       string
+	iconsPath string
+	res       *resources.Resources
+	gviz      *gographviz.Graph
 }
 
 // NewGraph returns a Graph of k8s resources
-func NewGraph(res *resources.Resources, dir string) *Graph {
-	g := &Graph{res: res, dir: dir, gviz: gographviz.NewGraph()}
+func NewGraph(res *resources.Resources, dir, iconsPath string) *Graph {
+	g := &Graph{res: res, dir: dir, iconsPath: iconsPath, gviz: gographviz.NewGraph()}
 	g.generate()
 
 	return g

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -24,6 +24,7 @@ import (
 var (
 	testns       = "testns"
 	dir          = "/testdir"
+	iconsPath    = "/testdir/icons"
 	goldenDir    = "testdata"
 	goldenSuffix = ".golden"
 	// if -update flag is specified on test run, golden file for the test will be updated
@@ -121,7 +122,7 @@ var (
 			OwnerReferences: []metav1.OwnerReference{{APIVersion: "batch/v1", Kind: "Job", Name: "job1"}}}},
 		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: testns, Name: "ds1"}},
 		&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Namespace: testns, Name: "job1",
-			OwnerReferences: []metav1.OwnerReference{{APIVersion: "batch/v1beta1", Kind: "cronJob", Name: "cronjob1"}}}},
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "batch/v1beta1", Kind: "CronJob", Name: "cronjob1"}}}},
 		&batchv1.CronJob{ObjectMeta: metav1.ObjectMeta{Namespace: testns, Name: "cronjob1"}},
 	}
 )
@@ -132,8 +133,7 @@ func prepTestGraph(t *testing.T, objs ...runtime.Object) *Graph {
 	if err != nil {
 		t.Fatalf("NewResources failed: %v", err)
 	}
-
-	return NewGraph(res, dir)
+	return NewGraph(res, dir, iconsPath)
 }
 
 func getGoldenFilePath(name string) string {

--- a/pkg/graph/graph_utils.go
+++ b/pkg/graph/graph_utils.go
@@ -10,22 +10,24 @@ import (
 )
 
 // imagePath returns the path to the image file
-// path is {dir}/icons/{resource}-128.png
+// path is {dir}/{iconsDir}/{resource}-128.png
 // ex) /icons/pod-128.png
 func (g *Graph) imagePath(kind string) string {
-	return filepath.Join(g.dir, "icons", kind+imageSuffix)
+	return filepath.Join(g.iconsPath, kind+imageSuffix)
 }
 
 // clusterLabel returns the resource label for namespace
 // ex)
-//   <<TABLE BORDER="0"><TR><TD><IMG SRC="/icons/ns-128.png" /></TD></TR><TR><TD>my-namespace</TD></TR></TABLE>>
+//
+//	<<TABLE BORDER="0"><TR><TD><IMG SRC="/icons/ns-128.png" /></TD></TR><TR><TD>my-namespace</TD></TR></TABLE>>
 func (g *Graph) clusterLabel() string {
 	return g.resourceLabel("ns", g.res.Namespace)
 }
 
 // resourceLabel returns the resource label for a resource
 // ex)
-//   <<TABLE BORDER="0"><TR><TD><IMG SRC="/icons/pod-128.png" /></TD></TR><TR><TD>my-pod</TD></TR></TABLE>>
+//
+//	<<TABLE BORDER="0"><TR><TD><IMG SRC="/icons/pod-128.png" /></TD></TR><TR><TD>my-pod</TD></TR></TABLE>>
 func (g *Graph) resourceLabel(kind, name string) string {
 	return fmt.Sprintf("<<TABLE BORDER=\"0\"><TR><TD><IMG SRC=\"%s\" /></TD></TR><TR><TD>%s</TD></TR></TABLE>>", g.imagePath(kind), name)
 }

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 KEEP_RESULT="${KEEP_RESULT:-false}"
 
@@ -74,7 +74,7 @@ function create_cluster() {
 	curl -Lo ${TEST_KIND_BIN} https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64
 	chmod +x ${TEST_KIND_BIN}
 
-	# Change path for kubeconfig 
+	# Change path for kubeconfig
 	export KUBECONFIG=${TEST_KUBECONFIG_PATH}
 
 	# Create cluster
@@ -91,7 +91,7 @@ function prepare_all() {
 }
 
 function delete_cluster() {
-	# Change path for kubeconfig 
+	# Change path for kubeconfig
 	export KUBECONFIG=${TEST_KUBECONFIG_PATH}
 
 	# Delete cluster


### PR DESCRIPTION
Hi there,

Thanks for creating this handy utility! :tada:

I wanted to package this for Nix/NixOS and noticed that there are a couple issues that have to be resolved first.
For many use cases, it is inconvenient to require the icons directory to reside in the same directory as the `k8sviz` binary.

In case you install the Go version manually and put the `k8sviz` binary in say `/usr/local/bin`, you really don't want to have to copy a random directory containing icons in there as well, since this path is expected to only contain binaries

Therefore I propose introducing a flag that makes it possible to supply the path to any directory containing the required icons.
You could then for example put the icons in `/usr/local/share/k8sviz/` and run `k8sviz` like this:
```sh
k8sviz -i /usr/local/share/k8sviz
```

I made it possible to pass either an absolute path or one relative to the binary. It still defaults to `icons` so the default behaviour does not change.

I also updated the README and in two separate commits, fixed all Markdown linting errors found with `mdl` and improved the portability of the shell scripts.

Please let me know if anything is unclear